### PR TITLE
Enabled multiple EXIF Custom Info

### DIFF
--- a/MMM-BackgroundSlideshowInfo.js
+++ b/MMM-BackgroundSlideshowInfo.js
@@ -207,16 +207,15 @@ Module.register("MMM-BackgroundSlideshowInfo",{
             }
             location.innerHTML = locationInfo;
         }
-
+        var customInfo = "";
         for(configIndex in this.config.showCustom){
             var custom = document.getElementById("BGSS_CUSTOM");
             var configKey = this.config.showCustom[configIndex];
             var value = this.extract(configKey,this.exifData);
-            var customInfo = "";
             if(configKey.includes("Date")){
                 value = moment(this.parseExifDate(value)).format(this.config.formatDate);
             }
-            customInfo = customInfo + value;
+            customInfo = customInfo + value +" ";
             custom.innerHTML = customInfo;
         }
 


### PR DESCRIPTION
You can see only one Custom Info tag in the config.js, the last one.
Moved definition "var customInfo" outside the for cycle and added space between values.